### PR TITLE
Defect fix/prevent resetting to defaults if term input is locked

### DIFF
--- a/playwright-tests/Settings.spec.ts
+++ b/playwright-tests/Settings.spec.ts
@@ -9,6 +9,10 @@ test.describe("Settings", () => {
     mediumDuration: Locator,
     mediumUnlock: Locator,
     mediumDurationFormatInput: Locator,
+    mediumUnitName: Locator,
+    mediumBeginningDatepicker: Locator,
+    mediumEndDatepicker: Locator,
+    mediumUnitQuantity: Locator,
     hideButton: Locator,
     settingsPanel: Locator;
 
@@ -18,6 +22,10 @@ test.describe("Settings", () => {
     mediumLock = page.getByTestId("medium-lock");
     mediumDuration = page.getByTestId("medium-duration");
     mediumUnlock = page.getByTestId("medium-unlock");
+    mediumUnitName = page.getByTestId("medium-unit-name");
+    mediumBeginningDatepicker = page.getByTestId("medium-beginning-datepicker");
+    mediumEndDatepicker = page.getByTestId("medium-end-datepicker");
+    mediumUnitQuantity = page.getByTestId("medium-unit-qty");
     mediumDurationFormatInput = page.getByTestId(
       "medium-duration-format-input"
     );
@@ -30,33 +38,62 @@ test.describe("Settings", () => {
   });
 
   test.describe("Settings", () => {
-    test(`when closing settings panel, unlocked terminputs should lock  `, async () => {
-      // starts as locked
-      await expect(mediumUnlock).toHaveCount(0);
-      await expect(mediumLock).toHaveCount(1);
-      await expect(mediumDate).toHaveAttribute("disabled");
-      await expect(mediumDuration).toHaveAttribute("disabled");
-      await expect(mediumDurationFormatInput).toHaveAttribute("disabled");
+    test.describe("TermInputs", () => {
+      test(`when closing settings panel, unlocked terminputs should lock`, async () => {
+        // starts as locked
+        await expect(mediumUnlock).toHaveCount(0);
+        await expect(mediumLock).toHaveCount(1);
 
-      // shows as unlocked after clicking it
-      await mediumLock.click();
-      await expect(mediumUnlock).toHaveCount(1);
-      await expect(mediumLock).toHaveCount(0);
-      await expect(mediumDate).not.toHaveAttribute("disabled");
-      await expect(mediumDuration).not.toHaveAttribute("disabled");
-      await expect(mediumDurationFormatInput).not.toHaveAttribute("disabled");
+        // shows as unlocked after clicking it
+        await mediumLock.click();
+        await expect(mediumUnlock).toHaveCount(1);
+        await expect(mediumLock).toHaveCount(0);
 
-      // close and reopen the settings
-      await hideButton.click();
-      await expect(settingsPanel).toHaveClass(/hidden/);
-      await settingsButton.click();
+        // close and reopen the settings
+        await hideButton.click();
+        await expect(settingsPanel).toHaveClass(/hidden/);
+        await settingsButton.click();
 
-      // assert that termInputs have locked when the setttings closed.
-      await expect(mediumUnlock).toHaveCount(0);
-      await expect(mediumLock).toHaveCount(1);
-      await expect(mediumDate).toHaveAttribute("disabled");
-      await expect(mediumDuration).toHaveAttribute("disabled");
-      await expect(mediumDurationFormatInput).toHaveAttribute("disabled");
+        // assert that termInputs have locked when the setttings closed.
+        await expect(mediumUnlock).toHaveCount(0);
+        await expect(mediumLock).toHaveCount(1);
+      });
+      test(`termInput's respect locked status`, async () => {
+        // term inputs are locked
+        await expect(mediumUnlock).toHaveCount(0);
+        await expect(mediumLock).toHaveCount(1);
+        // check these inputs before we change the type
+        await expect(mediumUnitQuantity).toHaveAttribute("disabled");
+        await expect(mediumDurationFormatInput).toHaveAttribute("disabled");
+
+        // shows as unlocked after clicking it
+        await mediumLock.click();
+        await expect(mediumUnlock).toHaveCount(1);
+        await expect(mediumLock).toHaveCount(0);
+
+        // inputs are disabled
+        await expect(mediumUnitQuantity).not.toHaveAttribute("disabled");
+        await expect(mediumDurationFormatInput).not.toHaveAttribute("disabled");
+        await expect(mediumDate).not.toHaveAttribute("disabled");
+        await expect(mediumDuration).not.toHaveAttribute("disabled");
+        await expect(mediumUnitName).not.toHaveAttribute("disabled");
+        await expect(mediumBeginningDatepicker).not.toHaveAttribute("disabled");
+
+        // click mediumDate to enable end date input
+        await mediumDate.click();
+        await expect(mediumEndDatepicker).toBeVisible();
+        await expect(mediumEndDatepicker).not.toHaveAttribute("disabled");
+
+        // relock settings
+        await mediumUnlock.click();
+
+        // assert that inputs are disabled as expected
+        await expect(mediumDate).toHaveAttribute("disabled");
+        await expect(mediumDuration).toHaveAttribute("disabled");
+        await expect(mediumUnitName).toHaveAttribute("disabled");
+        await expect(mediumBeginningDatepicker).toHaveAttribute("disabled");
+        await expect(mediumEndDatepicker).toHaveAttribute("disabled");
+      });
     });
   });
 });

--- a/playwright-tests/Settings.spec.ts
+++ b/playwright-tests/Settings.spec.ts
@@ -13,6 +13,7 @@ test.describe("Settings", () => {
     mediumBeginningDatepicker: Locator,
     mediumEndDatepicker: Locator,
     mediumUnitQuantity: Locator,
+    mediumRestoreDefaults: Locator,
     hideButton: Locator,
     settingsPanel: Locator;
 
@@ -29,6 +30,8 @@ test.describe("Settings", () => {
     mediumDurationFormatInput = page.getByTestId(
       "medium-duration-format-input"
     );
+    mediumRestoreDefaults = page.getByTestId("medium-restore-defaults");
+
     hideButton = page.getByTestId("hide-button");
     settingsPanel = page.getByTestId("hideable-settings");
 
@@ -93,6 +96,28 @@ test.describe("Settings", () => {
         await expect(mediumUnitName).toHaveAttribute("disabled");
         await expect(mediumBeginningDatepicker).toHaveAttribute("disabled");
         await expect(mediumEndDatepicker).toHaveAttribute("disabled");
+      });
+      test(`locking termInput also prevents resetting values`, async () => {
+        // Unlock termInput settings
+        await mediumLock.click();
+
+        // set a new value for Unit Name
+        mediumUnitName.fill("NewValue");
+        await expect(mediumUnitName).toHaveValue("NewValue");
+
+        // re-lock TermInput
+        await mediumUnlock.click();
+
+        // attempt to reset values, but fail
+        await mediumRestoreDefaults.click();
+        await expect(mediumUnitName).toHaveValue("NewValue");
+
+        // unlock TermInput again
+        await mediumLock.click();
+
+        // attempt to reset values and succeed
+        await mediumRestoreDefaults.click();
+        await expect(mediumUnitName).toHaveValue("Month");
       });
     });
   });

--- a/src/components/settings/term/Duration.tsx
+++ b/src/components/settings/term/Duration.tsx
@@ -48,6 +48,7 @@ export const Duration = ({
         type="number"
         name={categoryUnitQty}
         id={categoryUnitQty}
+        data-testid={categoryUnitQty}
         min="1"
         max="100"
         className="pt-2 pl-1 h-6 w-12 leading-loose"

--- a/src/components/settings/term/SelectDate.tsx
+++ b/src/components/settings/term/SelectDate.tsx
@@ -54,7 +54,7 @@ export const SelectDate = ({
   if ("min" in limit && limit.min) {
     formattedLimit.min = DateTime.fromISO(limit.min).toISODate() ?? undefined;
   }
-  const categoryDatePicker = `${category}-${title}-datepicker`;
+  const categoryDatePicker = `${category}-${title.toLowerCase()}-datepicker`;
   return (
     <div className="inline-block w-1/2">
       <label htmlFor={categoryDatePicker}> {title}: </label>
@@ -62,6 +62,7 @@ export const SelectDate = ({
         type="date"
         {...formattedLimit}
         id={categoryDatePicker}
+        data-testid={categoryDatePicker}
         name={categoryDatePicker}
         value={DateTime.fromISO(date).toISODate() ?? ""}
         style={{ backgroundColor: enabled ? "white" : "darkgray" }}

--- a/src/components/settings/term/TermInputs.tsx
+++ b/src/components/settings/term/TermInputs.tsx
@@ -88,12 +88,14 @@ export const TermInputs = ({
         />
         <Icon
           onClick={() => {
-            setStartDate(defaultTerms[termString].startDate ?? "");
-            setEndDate(defaultTerms[termString].endDate ?? "");
-            setUnitType(defaultTerms[termString].unitType);
-            setTitle(defaultTerms[termString].title);
-            setRepeat(defaultTerms[termString].repeat);
-            setDuration(defaultTerms[termString].duration);
+            if (enabled) {
+              setStartDate(defaultTerms[termString].startDate ?? "");
+              setEndDate(defaultTerms[termString].endDate ?? "");
+              setUnitType(defaultTerms[termString].unitType);
+              setTitle(defaultTerms[termString].title);
+              setRepeat(defaultTerms[termString].repeat);
+              setDuration(defaultTerms[termString].duration);
+            }
           }}
           data-testid={`${category}-restore-defaults`}
           icon={faArrowRightFromBracket}

--- a/src/components/settings/term/TermName.tsx
+++ b/src/components/settings/term/TermName.tsx
@@ -20,6 +20,7 @@ export const TermName = ({
       <label htmlFor={categoryName}>Name: </label>
       <input
         id={categoryName}
+        data-testid={categoryName}
         name={categoryName}
         type="text"
         value={title}


### PR DESCRIPTION
Prevents resetting values when TermInput is locked.
Adds Functional Tests for inputs and to prevent resetting values to default.